### PR TITLE
Update TMFC001 to match specification by Ian Turkington (1 of 2)

### DIFF
--- a/TMFC001 Product Catalog Mgmt/TMFC001 - Component-OAS-Specification-v1beta2.yaml
+++ b/TMFC001 Product Catalog Mgmt/TMFC001 - Component-OAS-Specification-v1beta2.yaml
@@ -1,4 +1,4 @@
-apiVersion: oda.tmforum.org/v1beta2
+apiVersion: oda.tmforum.org/v1beta3
 kind: component
 metadata:
   name: components.oda.tmforum.org
@@ -7,7 +7,7 @@ spec:
   componentName: ProductCatalogManagement
   componentFunctionalBlock: CoreCommerce 
   componenentDescription: The Product Catalog Management ODA Component is responsible for organizing the collection of Products and Product Offerings specifications that identify and define all requirements of a product or a product offering that can be commercialized.
-  componentVersion: 1.2.0
+  componentVersion: 1.2.1
   componentStatus: specified 
   componentPublicationDate: 2023-08-18
   maintainers:
@@ -91,7 +91,7 @@ coreFunction:
           - GET /id
     - name: PromotionManagement
       id: TMF671
-      isRequired: yes
+      isRequired: no
       version: 4.0
       specification: https://github.com/tmforum-apis/TMF701_ProcessFlow/blob/master/TMF701-ProcessFlow-v4.0.0.swagger.json
       implementation: /{{.Release.Name}}-PromotionManagement
@@ -116,12 +116,11 @@ coreFunction:
       path: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/PromotionManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/PromotionManagement/v4/docs
       port: 8080
-      rerouces: 
-      - event:  
-        - GET
-        - GET /id
+      resources: 
+      - listener:  
         - POST
-        - PATCH
+      - hub:  
+        - POST
         - DELETE
     dependantAPIs:
     - name: ServiceCatalogManagement 
@@ -141,14 +140,27 @@ coreFunction:
       specification: https://raw.githubusercontent.com/tmforum-apis/TMF701_ProcessFlow/master/TMF701-ProcessFlow-v4.0.0.swagger.json
       apitype: openapi
       resources:  
-      - PartyRoleManagement:
+      - PartyRole:
+        - GET
+        - GET /id
+    - name: Party
+      id: TMF632
+      isRequired: no
+      version: 4.0
+      specification: https://raw.githubusercontent.com/tmforum-apis/TMF632_Party/master/TMF632-Party-v4.0.0.swagger.json
+      apitype: openapi
+      resources:  
+      - Individual:
+        - GET
+        - GET /id
+      - Organisation:
         - GET
         - GET /id
     - name: ResourceCatalog
-      id: TMF672
+      id: TMF634
       isRequired: no
       version: 4.0
-      specification: https://raw.githubusercontent.com/tmforum-apis/TMF688-ResourceCatalog/master/TMF688-ResourceCatalog-v4.0.0.swagger.json
+      specification: https://raw.githubusercontent.com/tmforum-apis/TMF634-ResourceCatalog/master/TMF634-ResourceCatalog-v4.0.0.swagger.json
       apitype: openapi
       resources:
       - resourceSpecification:
@@ -165,6 +177,16 @@ coreFunction:
         - GET
         - GET /id
       - agreementSpecification:
+        - GET
+        - GET /id
+    - name: SLA
+      id: TMF623
+      isRequired: no
+      version: 4.0
+      specification: https://raw.githubusercontent.com/tmforum-apis/TMF623_SLA/master/TMF623-SLA-v4.0.0.swagger.json
+      apitype: openapi
+      resources:  
+      - serviceLevelAgreement:
         - GET
         - GET /id
     - name: GeographicAddressManagement
@@ -224,11 +246,35 @@ coreFunction:
       specification: https://github.com/tmforum-apis/TMF620_ProductCatalog/blob/master/TMF620-ProductCatalog-v4.0.0.swagger.json     
       apitype: openapi     
       resources: 
-      - GET
-      - GET /id
-      - POST
-      - PATCH
-      - DELETE    
+      - catalog:
+        - GET
+        - GET /id
+      - category:
+        - GET
+        - GET /id
+        - POST
+        - PATCH
+        - DELETE
+      - productOffering:
+        - GET
+        - GET /id
+        - POST
+        - PATCH
+        - DELETE
+      - ProductOfferingPrice:
+        - GET
+        - GET /id
+        - POST
+        - PATCH
+        - DELETE
+      - importJob:
+        - GET
+        - POST
+        - DELETE
+      - exportJob:
+        - GET
+        - POST
+        - DELETE
     - name: Event 
       id: TMF688
       isRequired: no
@@ -237,6 +283,7 @@ coreFunction:
       apitype: openapi     
       resources: 
       - event:
+        - POST
         - GET
         - GET /id                                  
     publishedEvents: 
@@ -294,39 +341,6 @@ coreFunction:
         - taskFlowAttributeValueChangeEvent
         - taskFlowInformationRequiredEvent
     subscribedEvents: 
-    - name: ResourceActivationAndConfiguration
-      specification: https://open-api.tmforum.org/TMF633-Servicecatalog-v4.0.0.swagger.json
-      call-back: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/servicepecification/call-back
-      port: 80
-      implementation: /{{.Release.Name}}-ResourceActivationAndConfiguration
-      apitype: openapi
-      resources: 
-      - ResourceActivationAndConfiguration:
-        - resourceCreateEvent
-        - resourceAttributeValueChangeEvent
-        - resourceStateChangeEvent
-        - resourceDeleteEvent
-        - monitorCreateEvent
-        - monitorStatechangeEvent
-        - monitorAttributeValueChange
-        - monitorDeleteEvent
-      - ResourceFunctionActivationAndConfiguration:
-        - MigrateCreateEvent
-        - MigrateAttributeValueChangeEvent
-        - MigrateStateChangeEvent
-        - MigratedeleteEvent
-        - HealCreateEvent
-        - HealAttributeValueChangeEvent
-        - HealStateChangeEvent
-        - HealDeleteEvent
-        - ScaleCreateEvent
-        - ScaleAttributeValueChangeEvent
-        - ScaleStateChangeEvent
-        - ScaleDeleteEvent
-        - ResourceFunctionCreateEvent
-        - ResourceFunctionAttributeValueChangeEvent
-        - ResourceFunctionStateChangeEvent
-        - ResourceFunctionDeleteEvent    
     - name: ServiceCatalogManagement
       specification: https://open-api.tmforum.org/TMF633-Servicecatalog-v4.0.0.swagger.json
       call-back: /{{.Release.Name}}-{{.Values.component.type}}/tmf-api/servicepecification/call-back
@@ -343,7 +357,7 @@ coreFunction:
         - resourceSpecificationCreateEvent
         - resourceSpecificationChangeEvent
         - resourceSpecificationDeleteEvent         
-management: []
-reporting: []
-security: []
+managementFunction: []
+reportingFunction: []
+securityFunction: []
   


### PR DESCRIPTION
Changed to match v1beta3 spec.
Changed to match spec version.
TMF671 now optional.
TMF688 corrected.
TMF669 corrected resource name.
TMF632 added.
TMF634 had wrong ID (was TMF672)
TMF623 added
TMF688 operations corrected
TMF620 resources added
Subscribed events: ResourceActivationAndConfiguration removed. Subscribed events: PartyRoleManagement, UserRolePermissions and Party are all missing from the YAML file. (This was not yet corrected.)